### PR TITLE
Handle unavailable glyphs

### DIFF
--- a/src/primitives/text.ts
+++ b/src/primitives/text.ts
@@ -3,6 +3,8 @@ import { CandyGraph } from "../candygraph";
 import { Primitive, Vector2, Vector4 } from "../common";
 import { Font } from "./font";
 
+const MAX_UNAVAILABLE_GLYPH_WARNINGS = 10;
+
 export type Options = {
   align?: number;
   anchor?: Vector2;
@@ -34,22 +36,13 @@ let quadBuffer = new Float32Array(1);
 let uvBuffer = new Float32Array(1);
 
 function getPositionBuffer(cg: CandyGraph) {
-  if (!cg.hasPositionBuffer('text')) {
-    cg.setPositionBuffer(
-      'text',
-      [0, 0, 1, 0, 1, 1, 0, 0, 1, 1, 0, 1]
-    );
+  if (!cg.hasPositionBuffer("text")) {
+    cg.setPositionBuffer("text", [0, 0, 1, 0, 1, 1, 0, 0, 1, 1, 0, 1]);
   }
-  return cg.getPositionBuffer('text');
+  return cg.getPositionBuffer("text");
 }
 
-export function createText(
-  cg: CandyGraph,
-  font: Font,
-  text: string,
-  position: Vector2,
-  options?: Options
-) {
+export function createText(cg: CandyGraph, font: Font, text: string, position: Vector2, options?: Options) {
   const quadGeometry = getPositionBuffer(cg)!;
   return new Text(cg.regl, quadGeometry, font, text, position, options);
 }
@@ -77,7 +70,12 @@ export class Text extends Primitive {
     const opts = { ...DEFAULTS, ...options };
 
     // Get a count of the actual number of characters we'll be creating quads for.
-    const charCount = text.replace(/ /g, "").replace(/\n/g, "").length;
+    let charCount = 0;
+    for (let i = 0; i < text.length; i++) {
+      const code = text.charCodeAt(i);
+      // We do not count whitespaces (code 32), line breaks (code 10), and unavailable glyphs
+      charCount += Number(Boolean(code !== 32 && code !== 10 && this.font.glyphs[code]));
+    }
 
     // Keep track of the current character.
     let charIndex = 0;
@@ -102,6 +100,10 @@ export class Text extends Primitive {
     // We'll store the width and char count of each line in this.
     const textMetrics = [];
 
+    // Counter for keeping track of unavailable glyphs to limit the number of
+    // console-logged warnings
+    let numUnavailableGlyphs = 0;
+
     // Iterate over each line.
     for (const line of lines) {
       const lineMetrics = {
@@ -121,11 +123,22 @@ export class Text extends Primitive {
         // Find the glyph for that character.
         const glyph = this.font.glyphs[char.charCodeAt(0)];
 
+        if (!glyph) {
+          ++numUnavailableGlyphs;
+
+          if (numUnavailableGlyphs < MAX_UNAVAILABLE_GLYPH_WARNINGS) {
+            console.warn(`The provided font does not contain a glyph for "${char}" (code: ${char.charCodeAt(0)})`);
+          } else if (numUnavailableGlyphs === MAX_UNAVAILABLE_GLYPH_WARNINGS) {
+            console.warn("Too many warnings of unavailable glyphs in the provided font. We'll stop logging warnings.");
+          }
+
+          continue;
+        }
+
         // If this isn't a space character, go ahead and append layout data.
         if (char !== " ") {
           // Calculate the amount to kern. Default to zero.
-          const kernAmount =
-            prevGlyph === null ? 0 : this.font.kern(prevGlyph.id, glyph.id);
+          const kernAmount = prevGlyph === null ? 0 : this.font.kern(prevGlyph.id, glyph.id);
 
           // Calculate and append the offset of the character quad.
           const ox = cx + glyph.xoffset + kernAmount;

--- a/src/primitives/text.ts
+++ b/src/primitives/text.ts
@@ -73,7 +73,7 @@ export class Text extends Primitive {
     let charCount = 0;
     for (let i = 0; i < text.length; i++) {
       const code = text.charCodeAt(i);
-      // We do not count whitespaces (code 32), line breaks (code 10), and unavailable glyphs
+      // We do not count whitespaces (code 32), line breaks (code 10), and unknown glyphs
       charCount += Number(Boolean(code !== 32 && code !== 10 && this.font.glyphs[code]));
     }
 
@@ -100,9 +100,9 @@ export class Text extends Primitive {
     // We'll store the width and char count of each line in this.
     const textMetrics = [];
 
-    // Counter for keeping track of unavailable glyphs to limit the number of
+    // Counter for keeping track of unknown glyphs to limit the number of
     // console-logged warnings
-    let numUnavailableGlyphs = 0;
+    let numUnknownGlyphs = 0;
 
     // Iterate over each line.
     for (const line of lines) {
@@ -124,12 +124,12 @@ export class Text extends Primitive {
         const glyph = this.font.glyphs[char.charCodeAt(0)];
 
         if (!glyph) {
-          ++numUnavailableGlyphs;
+          ++numUnknownGlyphs;
 
-          if (numUnavailableGlyphs < MAX_UNAVAILABLE_GLYPH_WARNINGS) {
+          if (numUnknownGlyphs < MAX_UNAVAILABLE_GLYPH_WARNINGS) {
             console.warn(`The provided font does not contain a glyph for "${char}" (code: ${char.charCodeAt(0)})`);
-          } else if (numUnavailableGlyphs === MAX_UNAVAILABLE_GLYPH_WARNINGS) {
-            console.warn("Too many warnings of unavailable glyphs in the provided font. We'll stop logging warnings.");
+          } else if (numUnknownGlyphs === MAX_UNAVAILABLE_GLYPH_WARNINGS) {
+            console.warn("Too many warnings of unknown glyphs in the provided font. We'll stop logging warnings.");
           }
 
           continue;


### PR DESCRIPTION
This PR attempts to fix #28.

Unknown glyphs are excluded from the count and not rendered at all. Up to `10` warnings per `Text` instance are logged before logging stops. Alternatively we could create a global counter and prevent logging after `100` warnings. Not sure which approach is better.

As mentioned in #28, since I don't think we can guarantee any character, I chose to simply skip unknown glyphs. Alternatively we could hard code one char into the Text class and have that display for unknown glyphs as suggest by @wwwtyro. My thinking was that that might be overkill if we anyway switch to something like https://github.com/mapbox/tiny-sdf in the nearish future.

Anyway, let me know what you think :) Feedback and changes are welcome.