### PR TITLE
Refactor CoordinateSystem and Composite to handle their own scope caches.

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -568,25 +568,27 @@ Returns a `LogScale` object.
 | domain    | Vector2 | The domain of this scale.   |
 | range     | Vector2 | The range of this scale.    |
 
-#### `createCartesianCoordinateSystem(xscale: Scale, yscale: Scale): CartesianCoordinateSystem`
+#### `createCartesianCoordinateSystem(cg: CandyGraph, xscale: Scale, yscale: Scale): CartesianCoordinateSystem`
 
 Returns a `CartesianCoordinateSystem`.
 
-| Parameter | Type  | Description               |
-| --------- | ----- | ------------------------- |
-| xscale    | Scale | The scale for the x-axis. |
-| yscale    | Scale | The scale for the y-axis. |
+| Parameter | Type       | Description                                        |
+| --------- | ---------- | -------------------------------------------------- |
+| cg        | CandyGraph | Required. The `CandyGraph` instance for rendering. |
+| xscale    | Scale      | The scale for the x-axis.                          |
+| yscale    | Scale      | The scale for the y-axis.                          |
 
-#### `createPolarCoordinateSystem(xscale: Scale, yscale: Scale): PolarCoordinateSystem`
+#### `createPolarCoordinateSystem(cg: CandyGraph, xscale: Scale, yscale: Scale): PolarCoordinateSystem`
 
 Returns a `PolarCoordinateSystem`.
 
-| Parameter    | Type  | Description                                           |
-| ------------ | ----- | ----------------------------------------------------- |
-| radialScale  | Scale | The scale for the radial axis (distance from origin). |
-| angularScale | Scale | The scale for the angular axis.                       |
-| xScale       | Scale | The scale for the x-axis.                             |
-| yScale       | Scale | The scale for the y-axis.                             |
+| Parameter    | Type       | Description                                           |
+| ------------ | ---------- | ----------------------------------------------------- |
+| cg           | CandyGraph | Required. The `CandyGraph` instance for rendering.    |
+| radialScale  | Scale      | The scale for the radial axis (distance from origin). |
+| angularScale | Scale      | The scale for the angular axis.                       |
+| xScale       | Scale      | The scale for the x-axis.                             |
+| yScale       | Scale      | The scale for the y-axis.                             |
 
 ### Properties
 

--- a/docs/examples/src/ex-00100-simple-plot.ts
+++ b/docs/examples/src/ex-00100-simple-plot.ts
@@ -10,7 +10,6 @@ import CandyGraph, {
   createCartesianCoordinateSystem,
 } from "../../../src";
 
-
 export default async function SimplePlot(cg: CandyGraph) {
   // Generate some x & y data.
   const xs = [];
@@ -35,6 +34,7 @@ export default async function SimplePlot(cg: CandyGraph) {
   // that we add 32 pixels of padding to the left and bottom
   // of the viewport, and 16 pixels to the top and right.
   const coords = createCartesianCoordinateSystem(
+    cg,
     createLinearScale([0, 1], [32 * dpr, viewport.width - 16 * dpr]),
     createLinearScale([0, 1], [32 * dpr, viewport.height - 16 * dpr])
   );

--- a/docs/examples/src/ex-00200-simple-plot-points.ts
+++ b/docs/examples/src/ex-00200-simple-plot-points.ts
@@ -38,6 +38,7 @@ export default async function SimplePlotPoints(cg: CandyGraph) {
   // that we add 32 pixels of padding to the left and bottom
   // of the viewport, and 16 pixels to the top and right.
   const coords = createCartesianCoordinateSystem(
+    cg,
     createLinearScale([0, 1], [32 * dpr, viewport.width - 16 * dpr]),
     createLinearScale([0, 1], [32 * dpr, viewport.height - 16 * dpr])
   );

--- a/docs/examples/src/ex-00250-area-chart.ts
+++ b/docs/examples/src/ex-00250-area-chart.ts
@@ -45,6 +45,7 @@ export default async function Area(cg: CandyGraph) {
   // that we add 32 pixels of padding to the left and bottom
   // of the viewport, and 16 pixels to the top and right.
   const coords = createCartesianCoordinateSystem(
+    cg,
     createLinearScale([0, 100], [32 * dpr, viewport.width - 16 * dpr]),
     createLinearScale([0, 100], [32 * dpr, viewport.height - 16 * dpr])
   );

--- a/docs/examples/src/ex-00300-bar-graph.ts
+++ b/docs/examples/src/ex-00300-bar-graph.ts
@@ -84,6 +84,7 @@ export default async function BarGraph(cg: CandyGraph) {
   const viewport = { x: 0, y: 0, width: 512 * dpr, height: 1024 * dpr };
 
   const coords = createCartesianCoordinateSystem(
+    cg,
     createLinearScale([0, 40000000], [160 * dpr, viewport.width - 24 * dpr]),
     createLinearScale([-0.75, keys.length - 1], [32 * dpr, viewport.height - 48 * dpr])
   );

--- a/docs/examples/src/ex-00350-scatter-plot.ts
+++ b/docs/examples/src/ex-00350-scatter-plot.ts
@@ -17,8 +17,7 @@ export default async function ScatterPlot(cg: CandyGraph) {
   for (let i = 0; i < 10000; i++) {
     const x = Math.random();
     const y = x;
-    const d =
-      0.8 * (Math.random() - 0.5) * Math.pow(Math.sin(x * Math.PI), 2.0);
+    const d = 0.8 * (Math.random() - 0.5) * Math.pow(Math.sin(x * Math.PI), 2.0);
     xs.push(x - d);
     ys.push(y + d);
   }
@@ -38,6 +37,7 @@ export default async function ScatterPlot(cg: CandyGraph) {
   // that we add 32 pixels of padding to the left and bottom
   // of the viewport, and 16 pixels to the top and right.
   const coords = createCartesianCoordinateSystem(
+    cg,
     createLinearScale([0, 1], [32 * dpr, viewport.width - 16 * dpr]),
     createLinearScale([0, 1], [32 * dpr, viewport.height - 16 * dpr])
   );

--- a/docs/examples/src/ex-00360-scatter-plot-zoom.ts
+++ b/docs/examples/src/ex-00360-scatter-plot-zoom.ts
@@ -48,6 +48,7 @@ export default async function ScatterPlotZoomPan(cg: CandyGraph) {
   // that we add 32 pixels of padding to the left and bottom
   // of the viewport, and 16 pixels to the top and right.
   const coords = createCartesianCoordinateSystem(
+    cg,
     createLinearScale([0, 1], [32 * dpr, viewport.width - 16 * dpr]),
     createLinearScale([0, 1], [32 * dpr, viewport.height - 16 * dpr])
   );

--- a/docs/examples/src/ex-00375-pie-chart.ts
+++ b/docs/examples/src/ex-00375-pie-chart.ts
@@ -65,6 +65,7 @@ export default async function PieChart(cg: CandyGraph) {
   ];
 
   const coords = createCartesianCoordinateSystem(
+    cg,
     createLinearScale([-1, 1], [0, viewport.width]),
     createLinearScale([-1, 1], [0, viewport.height])
   );

--- a/docs/examples/src/ex-00400-linear-log.ts
+++ b/docs/examples/src/ex-00400-linear-log.ts
@@ -24,6 +24,7 @@ export default async function LinearLog(cg: CandyGraph) {
   const viewport = { x: 0, y: 0, width: 384 * dpr, height: 384 * dpr };
 
   const coords = createCartesianCoordinateSystem(
+    cg,
     createLinearScale([0, 1], [40 * dpr, viewport.width - 16 * dpr]),
     createLogScale(10, [1, 100000], [32 * dpr, viewport.height - 16 * dpr])
   );

--- a/docs/examples/src/ex-00500-relative-time.ts
+++ b/docs/examples/src/ex-00500-relative-time.ts
@@ -39,10 +39,12 @@ export default async function RelativeTime(cg: CandyGraph) {
   // them.
   const yScale = createLinearScale([0, 25], [32 * dpr, viewport.height - 16 * dpr]);
   const axisCoords = createCartesianCoordinateSystem(
+    cg,
     createLinearScale([-1, 5], [16 * dpr, viewport.width - 16 * dpr]),
     yScale
   );
   const timeCoords = createCartesianCoordinateSystem(
+    cg,
     createLinearScale([-1, 5], [16 * dpr, viewport.width - 16 * dpr]),
     yScale
   );

--- a/docs/examples/src/ex-00600-time-and-state.ts
+++ b/docs/examples/src/ex-00600-time-and-state.ts
@@ -33,10 +33,12 @@ export default async function TimeAndState(cg: CandyGraph) {
   // them.
   const yScale = createLinearScale([0, 25], [32 * dpr, viewport.height - 16 * dpr]);
   const axisCoords = createCartesianCoordinateSystem(
+    cg,
     createLinearScale([-5, 0], [16 * dpr, viewport.width - 32 * dpr]),
     yScale
   );
   const timeCoords = createCartesianCoordinateSystem(
+    cg,
     createLinearScale([-5, 0], [16 * dpr, viewport.width - 32 * dpr]),
     yScale
   );

--- a/docs/examples/src/ex-00700-multi-viewport.ts
+++ b/docs/examples/src/ex-00700-multi-viewport.ts
@@ -22,11 +22,13 @@ export default async function MultiViewport(cg: CandyGraph) {
   canvas.height *= dpr;
 
   const coordstop = createCartesianCoordinateSystem(
+    cg,
     createLinearScale([0, 10], [40 * dpr, 256 * dpr - 16 * dpr]),
     createLinearScale([0, 10], [16 * dpr, 256 * dpr - 40 * dpr])
   );
 
   const coordsbottom = createCartesianCoordinateSystem(
+    cg,
     createLinearScale([0, 10], [40 * dpr, 256 * dpr - 16 * dpr]),
     createLinearScale([0, 10], [40 * dpr, 256 * dpr - 16 * dpr])
   );
@@ -128,6 +130,7 @@ export default async function MultiViewport(cg: CandyGraph) {
   ]);
 
   const coordsbig = createCartesianCoordinateSystem(
+    cg,
     createLinearScale([0, 10], [40 * dpr, 512 * dpr - 40 * dpr]),
     createLinearScale([0, 10], [32 * dpr, 512 * dpr - 32 * dpr])
   );

--- a/docs/examples/src/ex-00800-health-and-wealth.ts
+++ b/docs/examples/src/ex-00800-health-and-wealth.ts
@@ -29,11 +29,13 @@ export default async function HealthAndWealth(cg: CandyGraph): Promise<void> {
   const viewport = { x: 0, y: 0, width: canvas.width, height: canvas.height };
 
   const coords = createCartesianCoordinateSystem(
+    cg,
     createLogScale(10, [100, 100000], [64 * dpr, viewport.width - 20 * dpr]),
     createLinearScale([10, 90], [48 * dpr, viewport.height - 60 * dpr])
   );
 
   const screenCoords = createCartesianCoordinateSystem(
+    cg,
     createLinearScale([0, canvas.width], [0, canvas.width]),
     createLinearScale([0, canvas.height], [0, canvas.height])
   );

--- a/docs/examples/src/ex-00900-polar-plot.ts
+++ b/docs/examples/src/ex-00900-polar-plot.ts
@@ -35,6 +35,7 @@ export default async function PolarPlot(cg: CandyGraph) {
   // polar distance and angle (in radians), the next two map the resulting
   // cartesian coordinates to pixels.
   const coords = createPolarCoordinateSystem(
+    cg,
     createLinearScale([0, 1], [0, 1]), // radial scale
     createLinearScale([0, 1], [0, 1]), // angular scale
     createLinearScale([-1.1, 1.1], [16 * dpr, viewport.width - 16 * dpr]), // x scale

--- a/docs/examples/src/ex-01000-interleaved-line-segments.ts
+++ b/docs/examples/src/ex-01000-interleaved-line-segments.ts
@@ -2,11 +2,7 @@
 // <canvas id="ex-10000" style="box-shadow: 0px 0px 8px #ccc;" width=384 height=384></canvas>
 
 // skip-doc-start
-import CandyGraph, {
-  createLinearScale,
-  createLineSegments,
-  createCartesianCoordinateSystem,
-} from "../../../src";
+import CandyGraph, { createLinearScale, createLineSegments, createCartesianCoordinateSystem } from "../../../src";
 
 export default function InterleavedLineSegments(cg: CandyGraph) {
   // Scale the canvas by the device pixel ratio.
@@ -20,6 +16,7 @@ export default function InterleavedLineSegments(cg: CandyGraph) {
   const viewport = { x: 0, y: 0, width: 384 * dpr, height: 384 * dpr };
 
   const coords = createCartesianCoordinateSystem(
+    cg,
     createLinearScale([0, 1], [0, viewport.width]),
     createLinearScale([0, 1], [0, viewport.height])
   );

--- a/docs/examples/src/ex-01100-shapes.ts
+++ b/docs/examples/src/ex-01100-shapes.ts
@@ -22,6 +22,7 @@ export default function Shapes(cg: CandyGraph) {
   const viewport = { x: 0, y: 0, width: 384 * dpr, height: 384 * dpr };
 
   const coords = createCartesianCoordinateSystem(
+    cg,
     createLinearScale([0, 2 * Math.PI], [0, viewport.width]),
     createLinearScale([-1, 1], [0, viewport.height])
   );
@@ -45,12 +46,7 @@ export default function Shapes(cg: CandyGraph) {
     xs.push(x);
     ys0.push(Math.sin(x));
     ys1.push(Math.cos(x));
-    colors.push(
-      Math.random() * 0.75 + 0.25,
-      Math.random() * 0.75 + 0.25,
-      Math.random() * 0.75 + 0.25,
-      1
-    );
+    colors.push(Math.random() * 0.75 + 0.25, Math.random() * 0.75 + 0.25, Math.random() * 0.75 + 0.25, 1);
     const scale = (1 + Math.random() * 2) * dpr;
     scales.push(scale, scale);
     rotations.push(Math.random() * 2 * Math.PI);

--- a/docs/examples/src/ex-01200-interleaved-shapes.ts
+++ b/docs/examples/src/ex-01200-interleaved-shapes.ts
@@ -21,6 +21,7 @@ export default function InterleavedShapes(cg: CandyGraph) {
   const viewport = { x: 0, y: 0, width: 384 * dpr, height: 384 * dpr };
 
   const coords = createCartesianCoordinateSystem(
+    cg,
     createLinearScale([0, 1], [0, viewport.width]),
     createLinearScale([0, 1], [0, viewport.height])
   );

--- a/docs/examples/src/ex-01300-precision.ts
+++ b/docs/examples/src/ex-01300-precision.ts
@@ -38,6 +38,7 @@ export default async function PrecisionPlot(cg: CandyGraph) {
 
   // Create a coordinate system from two linear scales.
   const coords = createCartesianCoordinateSystem(
+    cg,
     createLinearScale([0, 1], [56 * dpr, viewport.width - 16 * dpr]),
     createLinearScale([0, 1], [108 * dpr, viewport.height - 24 * dpr])
   );

--- a/docs/tutorial/dist/index.html
+++ b/docs/tutorial/dist/index.html
@@ -63,7 +63,7 @@ to the full width and height of our viewport. Here they are:</p>
 <p>Now that we have our scales, we can create a coordinate system. Coordinate
 systems in CandyGraph wrap scales and add a little more GLSL glue code for
 use on the GPU. Here we’ll create a cartesian coordinate system:</p>
-<pre><code class="language-typescript">  const coords = createCartesianCoordinateSystem(xscale, yscale);
+<pre><code class="language-typescript">  const coords = createCartesianCoordinateSystem(cg, xscale, yscale);
 </code></pre>
 <p>Next we’re going to make some data for our plot. We’ll loop through 0 to 2π
 with a small increment for our x-values, and calculate the sine of each of
@@ -93,10 +93,7 @@ render a line strip. We’ll render it with width 2 pixels and in red
 been added to the DOM. Instead of doing that, we’ll use the <code>copyTo</code>
 utility function to copy it to the canvas we mentioned earlier, which has
 <code>id=&quot;doc_00100&quot;</code> defined:</p>
-<pre><code class="language-typescript">  cg.copyTo(
-    viewport,
-    document.getElementById(&quot;doc_00100&quot;) as HTMLCanvasElement
-  );
+<pre><code class="language-typescript">  cg.copyTo(viewport, document.getElementById(&quot;doc_00100&quot;) as HTMLCanvasElement);
 </code></pre>
 <div style="text-align: center">
 <canvas id="doc_00100" style="box-shadow: 0px 0px 8px #ccc;" width=512 height=384>
@@ -268,7 +265,7 @@ of 1 to 100000:</p>
 </code></pre>
 <p>Then we’ll create our coordinate system, grab the default font, clear the
 canvas, and render our data with axes:</p>
-<pre><code class="language-typescript">  const coords = createCartesianCoordinateSystem(xscale, yscale);
+<pre><code class="language-typescript">  const coords = createCartesianCoordinateSystem(cg, xscale, yscale);
   const font = await createDefaultFont(cg);
 
   cg.clear([1, 1, 1, 1]);
@@ -313,8 +310,7 @@ the x-axis:</p>
     createOrthoAxis(cg, coords, &quot;y&quot;, font, {
       tickLength: 5,
       tickOffset: 2,
-      labelFormatter: (n) =&gt;
-        n &gt;= 1000 ? Math.round(n / 1000).toString() + &quot;K&quot; : n.toString(),
+      labelFormatter: (n) =&gt; (n &gt;= 1000 ? Math.round(n / 1000).toString() + &quot;K&quot; : n.toString()),
     }),
   ]);
 </code></pre>
@@ -342,8 +338,7 @@ adding some minor ticks:</p>
       minorTickOffset: 2,
       tickLength: 5,
       tickOffset: 2,
-      labelFormatter: (n) =&gt;
-        n &gt;= 1000 ? Math.round(n / 1000).toString() + &quot;K&quot; : n.toString(),
+      labelFormatter: (n) =&gt; (n &gt;= 1000 ? Math.round(n / 1000).toString() + &quot;K&quot; : n.toString()),
     }),
   ]);
 </code></pre>
@@ -368,33 +363,23 @@ from the render function into a separate variable:</p>
       minorTickOffset: 2,
       tickLength: 5,
       tickOffset: 2,
-      labelFormatter: (n) =&gt;
-        n &gt;= 1000 ? Math.round(n / 1000).toString() + &quot;K&quot; : n.toString(),
+      labelFormatter: (n) =&gt; (n &gt;= 1000 ? Math.round(n / 1000).toString() + &quot;K&quot; : n.toString()),
     }),
   ];
 </code></pre>
 <p>Then we’ll access the <code>info</code> objects on that variable to build grids with
 the <code>Grid</code> helper CandyGraph provides. First we’ll make a grid with our
 major ticks on both the x- and y-axes:</p>
-<pre><code class="language-typescript">  const majorGrid = createGrid(
-    cg,
-    axes[0].info.ticks,
-    axes[1].info.ticks,
-    coords.xscale.domain,
-    coords.yscale.domain,
-    { color: [0.25, 0.25, 0.25, 1], width: 1 }
-  );
+<pre><code class="language-typescript">  const majorGrid = createGrid(cg, axes[0].info.ticks, axes[1].info.ticks, coords.xscale.domain, coords.yscale.domain, {
+    color: [0.25, 0.25, 0.25, 1],
+    width: 1,
+  });
 </code></pre>
 <p>Then we’ll create a grid for the minor ticks, which we only have on the
 y-axis, so we’ll pass an empty array for the x-axis ticks:</p>
-<pre><code class="language-typescript">  const minorGrid = createGrid(
-    cg,
-    [],
-    axes[1].info.minorTicks,
-    coords.xscale.domain,
-    coords.yscale.domain,
-    { color: [0.75, 0.75, 0.75, 1] }
-  );
+<pre><code class="language-typescript">  const minorGrid = createGrid(cg, [], axes[1].info.minorTicks, coords.xscale.domain, coords.yscale.domain, {
+    color: [0.75, 0.75, 0.75, 1],
+  });
 </code></pre>
 <p>And finally render our graph:</p>
 <pre><code class="language-typescript">  cg.render(coords, viewport, [
@@ -439,6 +424,7 @@ of data:</p>
 system with a bit of padding for our axes:</p>
 <pre><code class="language-typescript">  const viewport = { x: 0, y: 0, width: 1024, height: 384 };
   const coords = createCartesianCoordinateSystem(
+    cg,
     createLinearScale([-history, 0], [40, viewport.width - 16]),
     createLinearScale([-1, 1], [32, viewport.height - 16])
   );
@@ -585,8 +571,8 @@ y-axis:</p>
   const liny = createLinearScale([0, 10000], [24, viewport.height - 16]);
   const logy = createLogScale(10, [1, 10000], [24, viewport.height - 16]);
 
-  const linlin = createCartesianCoordinateSystem(linx, liny);
-  const linlog = createCartesianCoordinateSystem(linx, logy);
+  const linlin = createCartesianCoordinateSystem(cg, linx, liny);
+  const linlog = createCartesianCoordinateSystem(cg, linx, logy);
 </code></pre>
 <p>We’ll also hold onto our higher-level constructs by assigning them to a
 variable and keeping that reference to them, preventing garbage collection.</p>

--- a/docs/tutorial/src/doc-00100.ts
+++ b/docs/tutorial/src/doc-00100.ts
@@ -1,9 +1,5 @@
 // skip-doc-start
-import CandyGraph, {
-  createLinearScale,
-  createCartesianCoordinateSystem,
-  createLineStrip,
-} from "../../../src";
+import CandyGraph, { createLinearScale, createCartesianCoordinateSystem, createLineStrip } from "../../../src";
 // skip-doc-stop
 
 // ## Viewport, Scale, and Coordinates
@@ -34,7 +30,7 @@ export default function doc_00100(cg: CandyGraph): void {
   // Now that we have our scales, we can create a coordinate system. Coordinate
   // systems in CandyGraph wrap scales and add a little more GLSL glue code for
   // use on the GPU. Here we'll create a cartesian coordinate system:
-  const coords = createCartesianCoordinateSystem(xscale, yscale);
+  const coords = createCartesianCoordinateSystem(cg, xscale, yscale);
 
   // Next we're going to make some data for our plot. We'll loop through 0 to 2π
   // with a small increment for our x-values, and calculate the sine of each of
@@ -64,10 +60,7 @@ export default function doc_00100(cg: CandyGraph): void {
   // been added to the DOM. Instead of doing that, we'll use the `copyTo`
   // utility function to copy it to the canvas we mentioned earlier, which has
   // `id="doc_00100"` defined:
-  cg.copyTo(
-    viewport,
-    document.getElementById("doc_00100") as HTMLCanvasElement
-  );
+  cg.copyTo(viewport, document.getElementById("doc_00100") as HTMLCanvasElement);
 } // skip-doc
 
 // <div style="text-align: center">

--- a/docs/tutorial/src/doc-00200.ts
+++ b/docs/tutorial/src/doc-00200.ts
@@ -20,7 +20,7 @@ export default async function doc_00200(cg: CandyGraph) {
   const xscale = createLinearScale([0, 2 * Math.PI], [0, viewport.width]);
   const yscale = createLinearScale([-1, 1], [0, viewport.height]);
 
-  const coords = createCartesianCoordinateSystem(xscale, yscale);
+  const coords = createCartesianCoordinateSystem(cg, xscale, yscale);
 
   const xs = [];
   const ys = [];
@@ -62,10 +62,7 @@ export default async function doc_00200(cg: CandyGraph) {
   //
 
   // skip-doc-start
-  cg.copyTo(
-    viewport,
-    document.getElementById("doc_00200-000") as HTMLCanvasElement
-  );
+  cg.copyTo(viewport, document.getElementById("doc_00200-000") as HTMLCanvasElement);
   // skip-doc-stop
 
   // Wait, don't run away! It looks ugly, but there's a method to this madness.
@@ -92,10 +89,7 @@ export default async function doc_00200(cg: CandyGraph) {
     createOrthoAxis(cg, coords, "x", font),
     createOrthoAxis(cg, coords, "y", font),
   ]);
-  cg.copyTo(
-    viewport,
-    document.getElementById("doc_00200-001") as HTMLCanvasElement
-  );
+  cg.copyTo(viewport, document.getElementById("doc_00200-001") as HTMLCanvasElement);
   // skip-doc-stop
 
   // Okay, we can at least see our axes now. There's still issues, though. The
@@ -113,10 +107,7 @@ export default async function doc_00200(cg: CandyGraph) {
     createOrthoAxis(cg, coords, "y", font),
   ]);
   // skip-doc-start
-  cg.copyTo(
-    viewport,
-    document.getElementById("doc_00200-002") as HTMLCanvasElement
-  );
+  cg.copyTo(viewport, document.getElementById("doc_00200-002") as HTMLCanvasElement);
   // skip-doc-stop
 
   // <div style="text-align: center">
@@ -141,10 +132,7 @@ export default async function doc_00200(cg: CandyGraph) {
     createOrthoAxis(cg, coords, "y", font, { tickStep: 0.25 }),
   ]);
   // skip-doc-start
-  cg.copyTo(
-    viewport,
-    document.getElementById("doc_00200-003") as HTMLCanvasElement
-  );
+  cg.copyTo(viewport, document.getElementById("doc_00200-003") as HTMLCanvasElement);
   // skip-doc-stop
 
   // <div style="text-align: center">
@@ -169,10 +157,7 @@ export default async function doc_00200(cg: CandyGraph) {
     }),
   ]);
   // skip-doc-start
-  cg.copyTo(
-    viewport,
-    document.getElementById("doc_00200-004") as HTMLCanvasElement
-  );
+  cg.copyTo(viewport, document.getElementById("doc_00200-004") as HTMLCanvasElement);
   // skip-doc-stop
 
   // <div style="text-align: center">
@@ -201,10 +186,7 @@ export default async function doc_00200(cg: CandyGraph) {
     }),
   ]);
   // skip-doc-start
-  cg.copyTo(
-    viewport,
-    document.getElementById("doc_00200-005") as HTMLCanvasElement
-  );
+  cg.copyTo(viewport, document.getElementById("doc_00200-005") as HTMLCanvasElement);
   // skip-doc-stop
 
   // <div style="text-align: center">
@@ -236,10 +218,7 @@ export default async function doc_00200(cg: CandyGraph) {
     }),
   ]);
   // skip-doc-start
-  cg.copyTo(
-    viewport,
-    document.getElementById("doc_00200-006") as HTMLCanvasElement
-  );
+  cg.copyTo(viewport, document.getElementById("doc_00200-006") as HTMLCanvasElement);
   // skip-doc-stop
 
   // <div style="text-align: center">

--- a/docs/tutorial/src/doc-00300.ts
+++ b/docs/tutorial/src/doc-00300.ts
@@ -41,7 +41,7 @@ export default async function doc_00300(cg: CandyGraph) {
 
   // Then we'll create our coordinate system, grab the default font, clear the
   // canvas, and render our data with axes:
-  const coords = createCartesianCoordinateSystem(xscale, yscale);
+  const coords = createCartesianCoordinateSystem(cg, xscale, yscale);
   const font = await createDefaultFont(cg);
 
   cg.clear([1, 1, 1, 1]);
@@ -69,10 +69,7 @@ export default async function doc_00300(cg: CandyGraph) {
   //
 
   // skip-doc-start
-  cg.copyTo(
-    viewport,
-    document.getElementById("doc_00300-000") as HTMLCanvasElement
-  );
+  cg.copyTo(viewport, document.getElementById("doc_00300-000") as HTMLCanvasElement);
   // skip-doc-stop
 
   // Note that the `OrthoAxis` detected that we're using a logarithmic scale on
@@ -98,8 +95,7 @@ export default async function doc_00300(cg: CandyGraph) {
     createOrthoAxis(cg, coords, "y", font, {
       tickLength: 5,
       tickOffset: 2,
-      labelFormatter: (n) =>
-        n >= 1000 ? Math.round(n / 1000).toString() + "K" : n.toString(),
+      labelFormatter: (n) => (n >= 1000 ? Math.round(n / 1000).toString() + "K" : n.toString()),
     }),
   ]);
 
@@ -110,10 +106,7 @@ export default async function doc_00300(cg: CandyGraph) {
   //
 
   // skip-doc-start
-  cg.copyTo(
-    viewport,
-    document.getElementById("doc_00300-001") as HTMLCanvasElement
-  );
+  cg.copyTo(viewport, document.getElementById("doc_00300-001") as HTMLCanvasElement);
   // skip-doc-stop
 
   // We can make the logarithmic nature of the y-axis a little more obvious by
@@ -139,8 +132,7 @@ export default async function doc_00300(cg: CandyGraph) {
       minorTickOffset: 2,
       tickLength: 5,
       tickOffset: 2,
-      labelFormatter: (n) =>
-        n >= 1000 ? Math.round(n / 1000).toString() + "K" : n.toString(),
+      labelFormatter: (n) => (n >= 1000 ? Math.round(n / 1000).toString() + "K" : n.toString()),
     }),
   ]);
 
@@ -151,10 +143,7 @@ export default async function doc_00300(cg: CandyGraph) {
   //
 
   // skip-doc-start
-  cg.copyTo(
-    viewport,
-    document.getElementById("doc_00300-002") as HTMLCanvasElement
-  );
+  cg.copyTo(viewport, document.getElementById("doc_00300-002") as HTMLCanvasElement);
   // skip-doc-stop
 
   // Sometimes it's helpful to display a grid on your plot to make it easier to
@@ -175,33 +164,23 @@ export default async function doc_00300(cg: CandyGraph) {
       minorTickOffset: 2,
       tickLength: 5,
       tickOffset: 2,
-      labelFormatter: (n) =>
-        n >= 1000 ? Math.round(n / 1000).toString() + "K" : n.toString(),
+      labelFormatter: (n) => (n >= 1000 ? Math.round(n / 1000).toString() + "K" : n.toString()),
     }),
   ];
 
   // Then we'll access the `info` objects on that variable to build grids with
   // the `Grid` helper CandyGraph provides. First we'll make a grid with our
   // major ticks on both the x- and y-axes:
-  const majorGrid = createGrid(
-    cg,
-    axes[0].info.ticks,
-    axes[1].info.ticks,
-    coords.xscale.domain,
-    coords.yscale.domain,
-    { color: [0.25, 0.25, 0.25, 1], width: 1 }
-  );
+  const majorGrid = createGrid(cg, axes[0].info.ticks, axes[1].info.ticks, coords.xscale.domain, coords.yscale.domain, {
+    color: [0.25, 0.25, 0.25, 1],
+    width: 1,
+  });
 
   // Then we'll create a grid for the minor ticks, which we only have on the
   // y-axis, so we'll pass an empty array for the x-axis ticks:
-  const minorGrid = createGrid(
-    cg,
-    [],
-    axes[1].info.minorTicks,
-    coords.xscale.domain,
-    coords.yscale.domain,
-    { color: [0.75, 0.75, 0.75, 1] }
-  );
+  const minorGrid = createGrid(cg, [], axes[1].info.minorTicks, coords.xscale.domain, coords.yscale.domain, {
+    color: [0.75, 0.75, 0.75, 1],
+  });
 
   cg.clear([1, 1, 1, 1]); // skip-doc
 
@@ -223,9 +202,6 @@ export default async function doc_00300(cg: CandyGraph) {
   //
 
   // skip-doc-start
-  cg.copyTo(
-    viewport,
-    document.getElementById("doc_00300-003") as HTMLCanvasElement
-  );
+  cg.copyTo(viewport, document.getElementById("doc_00300-003") as HTMLCanvasElement);
   // skip-doc-stop
 } // skip-doc

--- a/docs/tutorial/src/doc-00400.ts
+++ b/docs/tutorial/src/doc-00400.ts
@@ -41,6 +41,7 @@ export default async function doc_00400(cg: CandyGraph) {
   // system with a bit of padding for our axes:
   const viewport = { x: 0, y: 0, width: 1024, height: 384 };
   const coords = createCartesianCoordinateSystem(
+    cg,
     createLinearScale([-history, 0], [40, viewport.width - 16]),
     createLinearScale([-1, 1], [32, viewport.height - 16])
   );

--- a/docs/tutorial/src/doc-00500.ts
+++ b/docs/tutorial/src/doc-00500.ts
@@ -62,8 +62,8 @@ export default async function doc_00500(cg: CandyGraph) {
   const liny = createLinearScale([0, 10000], [24, viewport.height - 16]);
   const logy = createLogScale(10, [1, 10000], [24, viewport.height - 16]);
 
-  const linlin = createCartesianCoordinateSystem(linx, liny);
-  const linlog = createCartesianCoordinateSystem(linx, logy);
+  const linlin = createCartesianCoordinateSystem(cg, linx, liny);
+  const linlog = createCartesianCoordinateSystem(cg, linx, logy);
 
   // We'll also hold onto our higher-level constructs by assigning them to a
   // variable and keeping that reference to them, preventing garbage collection.

--- a/src/candygraph.ts
+++ b/src/candygraph.ts
@@ -1,6 +1,6 @@
 import REGL, { DrawCommand, Regl, Buffer, Vec4 } from "regl";
 import { CoordinateSystem } from "./coordinates/coordinate-system";
-import { Viewport, Renderable, RenderableType, Primitive, Composite } from "./common";
+import { Viewport, Renderable, RenderableType, Primitive } from "./common";
 
 type Props = {
   resolution: [number, number];
@@ -33,9 +33,7 @@ export class CandyGraph {
   public readonly regl: Regl;
   public readonly canvas: HTMLCanvasElement;
 
-  private commandCache: { [glsl: string]: Map<Function, DrawCommand> } = {};
-  private coordinateScopeCache = new Map<CoordinateSystem, DrawCommand>();
-  private compositeScopeCache = new Map<Function, DrawCommand | null>();
+  private commandCache = new Map<string, Map<Function, DrawCommand>>();
   private scope: DrawCommand;
   private positionBufferCache = new Map<string, Buffer>();
 
@@ -70,6 +68,41 @@ export class CandyGraph {
     this.regl.clear({ color: color as Vec4 });
   };
 
+  public render = (coords: CoordinateSystem, viewport: Viewport, renderable: Renderable): void => {
+    coords.scope(coords.props(), () => {
+      this.scope(
+        {
+          resolution: [viewport.width, viewport.height],
+          viewport,
+        },
+        () => {
+          this.recursiveRender(coords, renderable);
+        }
+      );
+    });
+  };
+
+  private recursiveRender(coords: CoordinateSystem, renderable: Renderable) {
+    if (Array.isArray(renderable)) {
+      for (const element of renderable) {
+        this.recursiveRender(coords, element);
+      }
+    } else {
+      if (renderable.kind === RenderableType.Primitive) {
+        const command = this.getCommand(coords, renderable);
+        renderable.render(command);
+      } else if (renderable.kind === RenderableType.Composite) {
+        if (renderable.scope) {
+          renderable.scope(renderable.props(coords), () => {
+            this.recursiveRender(coords, renderable.children());
+          });
+        } else {
+          this.recursiveRender(coords, renderable.children());
+        }
+      }
+    }
+  }
+
   public hasPositionBuffer = (name: string): boolean => {
     return this.positionBufferCache.has(name);
   };
@@ -89,19 +122,24 @@ export class CandyGraph {
     this.positionBufferCache.clear();
   };
 
-  public render = (coords: CoordinateSystem, viewport: Viewport, renderable: Renderable): void => {
-    this.getCoordinateScope(coords)({ ...coords.props() }, () => {
-      this.scope(
-        {
-          resolution: [viewport.width, viewport.height],
-          viewport,
-        },
-        () => {
-          this.recursiveRender(coords, renderable);
-        }
-      );
-    });
-  };
+  public destroy() {
+    this.clearPositionBuffers();
+    this.regl.destroy();
+  }
+
+  private getCommand(coords: CoordinateSystem, primitive: Primitive) {
+    let m0 = this.commandCache.get(coords.glsl);
+    if (!m0) {
+      m0 = new Map<Function, DrawCommand>();
+      this.commandCache.set(coords.glsl, m0);
+    }
+    let command = m0.get(primitive.constructor);
+    if (!command) {
+      command = primitive.command(coords.glsl + commonGLSL);
+      m0.set(primitive.constructor, command);
+    }
+    return command;
+  }
 
   public copyTo(sourceViewport: Viewport, destinationCanvas?: HTMLCanvasElement, destinationViewport?: Viewport) {
     // If we're not provided a canvas, make one.
@@ -136,64 +174,5 @@ export class CandyGraph {
     );
 
     return dest;
-  }
-
-  public destroy() {
-    this.clearPositionBuffers();
-    this.regl.destroy();
-  }
-
-  private recursiveRender(coords: CoordinateSystem, renderable: Renderable) {
-    if (Array.isArray(renderable)) {
-      for (const element of renderable) {
-        this.recursiveRender(coords, element);
-      }
-    } else {
-      if (renderable.kind === RenderableType.Primitive) {
-        const command = this.getCommand(coords, renderable);
-        renderable.render(command);
-      } else if (renderable.kind === RenderableType.Composite) {
-        const scope = this.getCompositeScope(renderable);
-        if (scope) {
-          scope(renderable.props(coords), () => {
-            this.recursiveRender(coords, renderable.children());
-          });
-        } else {
-          this.recursiveRender(coords, renderable.children());
-        }
-      }
-    }
-  }
-
-  private getCommand(coords: CoordinateSystem, primitive: Primitive) {
-    let m0 = this.commandCache[coords.glsl];
-    if (!m0) {
-      m0 = new Map<Function, DrawCommand>();
-      this.commandCache[coords.glsl] = m0;
-    }
-    let command = m0.get(primitive.constructor);
-    if (!command) {
-      command = primitive.command(coords.glsl + commonGLSL);
-      m0.set(primitive.constructor, command);
-    }
-    return command;
-  }
-
-  private getCoordinateScope(coords: CoordinateSystem) {
-    let scope = this.coordinateScopeCache.get(coords);
-    if (!scope) {
-      scope = coords.scope(this.regl);
-      this.coordinateScopeCache.set(coords, scope);
-    }
-    return scope;
-  }
-
-  private getCompositeScope(composite: Composite) {
-    let scope = this.compositeScopeCache.get(composite.constructor);
-    if (!scope) {
-      scope = composite.scope();
-      this.compositeScopeCache.set(composite.constructor, scope);
-    }
-    return scope;
   }
 }

--- a/src/candygraph.ts
+++ b/src/candygraph.ts
@@ -128,15 +128,15 @@ export class CandyGraph {
   }
 
   private getCommand(coords: CoordinateSystem, primitive: Primitive) {
-    let m0 = this.commandCache.get(coords.glsl);
-    if (!m0) {
-      m0 = new Map<Function, DrawCommand>();
-      this.commandCache.set(coords.glsl, m0);
+    let commands = this.commandCache.get(coords.glsl);
+    if (!commands) {
+      commands = new Map<Function, DrawCommand>();
+      this.commandCache.set(coords.glsl, commands);
     }
-    let command = m0.get(primitive.constructor);
+    let command = commands.get(primitive.constructor);
     if (!command) {
       command = primitive.command(coords.glsl + commonGLSL);
-      m0.set(primitive.constructor, command);
+      commands.set(primitive.constructor, command);
     }
     return command;
   }

--- a/src/common.ts
+++ b/src/common.ts
@@ -26,10 +26,7 @@ export abstract class Primitive {
 export abstract class Composite {
   public readonly kind = RenderableType.Composite;
   public abstract children(): Renderable;
-
-  public scope(): DrawCommand | null {
-    return null;
-  }
+  public readonly scope: DrawCommand | null = null;
 
   public props(coords: CoordinateSystem) {
     return {};

--- a/src/composites/scissor.ts
+++ b/src/composites/scissor.ts
@@ -1,7 +1,7 @@
+import { DrawCommand } from "regl";
 import { CandyGraph } from "../candygraph";
 import { Composite, Renderable } from "../common";
 import { CoordinateSystem } from "../coordinates/coordinate-system";
-import { Regl } from "regl";
 
 type Props = {
   box: { x: number; y: number; width: number; height: number };
@@ -16,14 +16,15 @@ export function createScissor(
   screenSpace: boolean,
   children: Renderable
 ): Scissor {
-  return new Scissor(cg.regl, x, y, width, height, screenSpace, children);
+  return new Scissor(cg, x, y, width, height, screenSpace, children);
 }
 
 export class Scissor extends Composite {
   private _children: Renderable;
+  public readonly scope: DrawCommand;
 
   constructor(
-    private regl: Regl,
+    cg: CandyGraph,
     public x: number,
     public y: number,
     public width: number,
@@ -33,16 +34,14 @@ export class Scissor extends Composite {
   ) {
     super();
 
-    this._children = children;
-  }
-
-  public scope() {
-    return this.regl({
+    this.scope = cg.regl({
       scissor: {
         enable: true,
-        box: this.regl.prop<Props, "box">("box"),
+        box: cg.regl.prop<Props, "box">("box"),
       },
     });
+
+    this._children = children;
   }
 
   public props(coords: CoordinateSystem) {

--- a/src/coordinates/coordinate-system.ts
+++ b/src/coordinates/coordinate-system.ts
@@ -1,4 +1,4 @@
-import { DrawCommand, Regl } from "regl";
+import { DrawCommand } from "regl";
 import { Vector2 } from "../common";
 
 export enum Kind {
@@ -9,7 +9,7 @@ export enum Kind {
 export abstract class CoordinateSystem {
   public abstract readonly kind: Kind;
   public abstract readonly glsl: string;
-  public abstract scope(regl: Regl): DrawCommand;
+  public abstract readonly scope: DrawCommand;
   public abstract props(): Record<string, unknown>;
   public abstract toDomain(rangeVector: Vector2): Vector2;
   public abstract toRange(domainVector: Vector2): Vector2;

--- a/src/primitives/font.ts
+++ b/src/primitives/font.ts
@@ -12,11 +12,7 @@ type Glyph = {
   uv: Vector2;
 };
 
-export function createFont(
-  cg: CandyGraph,
-  image: HTMLImageElement,
-  json: any
-) {
+export function createFont(cg: CandyGraph, image: HTMLImageElement, json: any) {
   return new Font(cg.regl, image, json);
 }
 
@@ -65,12 +61,15 @@ export class Font {
     this.maxid = this.glyphs.length;
     this.kernTable = new Int8Array(this.maxid * this.maxid);
     for (const kern of json.kernings) {
-      this.kernTable[kern.first * this.maxid + kern.second] =
-        scale * kern.amount;
+      this.kernTable[kern.first * this.maxid + kern.second] = scale * kern.amount;
     }
   }
 
   public kern(first: number, second: number) {
     return this.kernTable[first * this.maxid + second];
+  }
+
+  public dispose() {
+    this.texture.destroy();
   }
 }


### PR DESCRIPTION
What do you think about this, @flekschas? Will it solve most of your memory leak issue from #34? It's similar to your PR, just narrower in _scope_ (heh, heh):

- Uses your approach of passing the CG object into the coordinate system, which I think makes a lot of sense.
- Creates the the coordinate system scope at coordinate system construction time and stores it on the object. 
- Removes the coordinate scope cache from the CG object.
- Creates the composite scope at composite construction time and stores it on the object.
- Removes the composite scope cache from the CG object.

If this works for you, I'll take a stab at the `commandCache` cleanup separately.

(Side note: I still need to go update the API docs)