### PR TITLE
Fix a typo and expand explanation in v0.9.0 a bit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.9.0
 
-- Renamed `Grid.info` to `Grid.computed`.
+- Renamed `Grid.info` and `OrthoAxis.info` to `Grid.computed` and `OrthoAxis.computed` respectively.
 - Added support for using multiple draw calls per primitive. If you've been
   using a custom primitive, you'll need to do the following:
   - Rename your `command` function to `commands`.
@@ -14,7 +14,7 @@
 - Added the `OpaqueLineStrip` primitive and a deprecation warning when using
   `LineStrip`.
 
-([#44](https://github.com/wwwtyro/candygraph/pull/42))
+([#44](https://github.com/wwwtyro/candygraph/pull/44))
 
 ## 0.8.0
 


### PR DESCRIPTION
Super micro PR that's fixing the incorrect link to PR #44 and adds the prop change in `OrthoAxis`